### PR TITLE
Configuration for Travis CI and AppVeyor CI (MS Mingw64 build)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,59 @@
+language: cpp
+
+branches:
+  only:
+    - develop
+
+git:
+  quiet: true
+  submodules: false
+  depth: false
+
+script: make
+
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+            - gcc-4.9
+      env:
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+            - gcc-5
+      env:
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+            - gcc-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+    - os: linux
+      compiler: clang
+      env: 
+        - MATRIX_EVAL="CC=clang && CXX=clang++"
+    - os: osx
+      osx_image: xcode10
+      env: 
+        - MATRIX_EVAL="CC=clang && CXX=clang++"
+
+before_install:
+  - eval "${MATRIX_EVAL}"
+
+      
+      

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,8 @@
 language: cpp
-
-branches:
-  only:
-    - develop
-
-git:
-  quiet: true
-  submodules: false
-  depth: false
-
-script: make
-
+script: make ci
+os:
+  - linux
+  - osx
 matrix:
   include:
     - os: linux
@@ -51,9 +43,5 @@ matrix:
       osx_image: xcode10
       env: 
         - MATRIX_EVAL="CC=clang && CXX=clang++"
-
 before_install:
   - eval "${MATRIX_EVAL}"
-
-      
-      

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 OS=$(shell uname)
 PWD=$(shell pwd)
 
-CC   = gcc
-CXX  = g++
 INC  = -I./src -I./include
 LIBS = -L./lib -lClothoids
 DEFS =
@@ -19,12 +17,16 @@ ifneq (,$(findstring Linux, $(OS)))
   LDCONFIG = sudo ldconfig
 endif
 
+# check if the OS string contains 'Linux'
+ifneq (,$(findstring MINGW, $(OS)))
+  LIBS     = -static -L./lib -lClothoids
+  CXXFLAGS = -std=c++11 -Wall -O3 -Wno-sign-compare
+  AR       = ar rcs
+  LDCONFIG = sudo ldconfig
+endif
+
 # check if the OS string contains 'Darwin'
 ifneq (,$(findstring Darwin, $(OS)))
-  CC       = clang
-  CXX      = clang++
-  #CC       = gcc-7
-  #CXX      = g++-7
   LIBS     = -L./lib -lClothoids
   CXXFLAGS = -Wall -O3 -fPIC -Wno-sign-compare
   AR       = libtool -static -o
@@ -55,7 +57,14 @@ MKDIR = mkdir -p
 PREFIX    = /usr/local
 FRAMEWORK = Clothoids
 
-all: lib
+all: bin
+
+ci: bin
+	@echo " --- CLOUD COMPILER ---"
+	$(CXX) --version
+	@echo " --- CLOUD COMPILER ---"
+
+bin: lib
 	@$(MKDIR) bin
 	$(CXX) $(INC) $(CXXFLAGS) -o bin/testG2         tests-cpp/testG2.cc $(LIBS)
 	$(CXX) $(INC) $(CXXFLAGS) -o bin/testG2stat     tests-cpp/testG2stat.cc $(LIBS)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+version: 'Clothoids-{branch}.build.{build}'
+branches:
+  only:
+  - develop
+  - master
+image: Visual Studio 2015
+platform: x64
+environment:
+  MINGW_DIR: C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0
+before_build:
+  - set Path=%MINGW_DIR%\mingw32\bin;%Path%
+build_script:
+  - mingw32-make ci
+test: off
+deploy: off


### PR DESCRIPTION
This pull request contains configurations for compiling on Travis:
 - Linux gcc 4.8
 - Linux gcc 4.9
 - Linux gcc 5.5
 - Linux gcc 7.3
 - Linux llvm 5.0
 - OsX xcode 9.4 (llvm)
 - OsX xcode 10 (llvm)
and on AppVeyor
 - Windows 64 mingw32_64 gcc 5.3

When you will have time we can configure your Appveyor account. As next step we should transform the binaries in **unit tests** in some way. 