### PR TITLE
simple copy and paste error in matlab interface fixed

### DIFF
--- a/matlab/ClothoidCurve.m
+++ b/matlab/ClothoidCurve.m
@@ -140,11 +140,9 @@ classdef ClothoidCurve < CurveBase
       x0     = self.xBegin();
       y0     = self.yBegin();
       theta0 = self.thetaBegin();
-      k      = self.kappaBegin();
-      dk     = self.kappa_D();
-      x0 = self.xBegin();
-      [ x0, y0, theta0, k0, dk, L ] = ...
-        ClothoidCurveMexWrapper( 'getPars', self.objectHandle );
+      k0      = self.kappaBegin();
+      dk     = self.dkappa();
+      L      = self.length();
     end
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     function [P1,P2,P3] = bbTriangles( self, varargin )

--- a/matlab/CurveBase.m
+++ b/matlab/CurveBase.m
@@ -55,8 +55,8 @@ classdef CurveBase < handle
       feval( self.mexName, 'changeOrigin', self.objectHandle, newX0, newY0 );
     end
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    function [ theta, kappa, x, y ] = evaluate( self, s, varargin )
-      [ theta, kappa, x, y ] = feval( self.mexName, 'evaluate', self.objectHandle, s, varargin{:} );
+    function [ x, y, theta, kappa ] = evaluate( self, s, varargin )
+      [ x, y, theta, kappa ] = feval( self.mexName, 'evaluate', self.objectHandle, s, varargin{:} );
     end
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     function varargout = eval( self, varargin )


### PR DESCRIPTION
Fast fix of getPars() method of class ClothoidCurve.
Maybe the best way is to fix the mex method [ x0, y0, theta0, k0, dk, L ] =  ClothoidCurveMexWrapper( 'getPars', self.objectHandle ).