### PR TITLE
Fix the spelling of Clothoids, ClothoidList, ClothoidSplineG2, etc. in the docs (Followup)

### DIFF
--- a/docs_build/sphinx/Matlab_manual.rst
+++ b/docs_build/sphinx/Matlab_manual.rst
@@ -16,8 +16,8 @@ objects in the library:
 - Biarc
 - ClothoidCurve
 - PolyLine
-- ClothoisList
-- ClothoisSplineG2
+- ClothoidList
+- ClothoidSplineG2
 - Triangle2D
 - FresnelCS
 
@@ -531,7 +531,7 @@ an offset respect to the normal of the curve can be used
   XY_DDD        = CL.eval_DDD( s, offs );
 
 
-ClothoisList
+ClothoidList
 ------------
 
 
@@ -541,7 +541,7 @@ Documentation will be available soon, see examples in
 ``tests`` for the moments
 
 
-ClothoisSplineG2
+ClothoidSplineG2
 ----------------
 
 Implements the algorithm described in references [2] and [3].

--- a/src/Clothoids/ClothoidList.hxx
+++ b/src/Clothoids/ClothoidList.hxx
@@ -906,12 +906,12 @@ namespace G2lib {
     { this->resetLastInterval(); copy(s); }
 
     //!
-    //! Initialize the clothois list
+    //! Initialize the clothoid list
     //!
     void init();
 
     //!
-    //! Reserve memory for `n` clothois
+    //! Reserve memory for `n` clothoid
     //!
     void reserve( int_type n );
 
@@ -1104,7 +1104,7 @@ namespace G2lib {
     real_type closure_gap_ty() const { return this->ty_End() - this->ty_Begin(); }
 
     //!
-    //! check if clothois list is closed
+    //! check if clothoid list is closed
     //!
     //! \param[in] tol_xy position tolerance
     //! \param[in] tol_tg angle (tangent) tolerance
@@ -1272,12 +1272,12 @@ namespace G2lib {
     ClothoidCurve const & getAtS( real_type s ) const;
 
     //!
-    //! Return the numbber of clothois of the list
+    //! Return the numbber of clothoid of the list
     //!
     int_type numSegment() const { return int_type(m_clotoidList.size()); }
 
     //!
-    //! The list of clothois has total length \f$ L \f$
+    //! The list of clothoid has total length \f$ L \f$
     //! the parameter \f$ s \f$ us recomputed as \f$ s+kL\f$ in such a way
     //! \f$ s+kL\in[0,L)\f$ with \f$ k\in\mathbb{Z} \f$.
     //!
@@ -1855,7 +1855,7 @@ namespace G2lib {
     operator << ( ostream_type & stream, ClothoidList const & CL );
 
     //!
-    //! Return the clothois list as a list of nodes and curvatures
+    //! Return the clothoid list as a list of nodes and curvatures
     //!
     //! \param[out] s     nodes
     //! \param[out] kappa curvature
@@ -1865,7 +1865,7 @@ namespace G2lib {
     getSK( real_type * s, real_type * kappa ) const;
 
     //!
-    //! Return the clothois list as a list of nodes and curvatures
+    //! Return the clothoid list as a list of nodes and curvatures
     //!
     //! \param[out] s     nodes
     //! \param[out] kappa curvature
@@ -1882,7 +1882,7 @@ namespace G2lib {
     }
 
     //!
-    //! Return the clothois list as a list of nodes angles and curvatures
+    //! Return the clothoid list as a list of nodes angles and curvatures
     //!
     //! \param[out] s     nodes
     //! \param[out] theta angles
@@ -1897,7 +1897,7 @@ namespace G2lib {
     ) const;
 
     //!
-    //! Return the clothois list as a list of nodes angles and curvatures
+    //! Return the clothoid list as a list of nodes angles and curvatures
     //!
     //! \param[out] s     nodes
     //! \param[out] theta angles

--- a/toolbox/lib/PolyLine.m
+++ b/toolbox/lib/PolyLine.m
@@ -50,7 +50,7 @@ classdef PolyLine < CurveBase
     %> - CircleArc
     %> - Biarc
     %> - ClothoidCurve
-    %> - ClothoisList
+    %> - ClothoidList
     %>
     %> with a polyline
     %> 

--- a/toolbox/src/Clothoids/ClothoidList.hxx
+++ b/toolbox/src/Clothoids/ClothoidList.hxx
@@ -906,12 +906,12 @@ namespace G2lib {
     { this->resetLastInterval(); copy(s); }
 
     //!
-    //! Initialize the clothois list
+    //! Initialize the clothoid list
     //!
     void init();
 
     //!
-    //! Reserve memory for `n` clothois
+    //! Reserve memory for `n` clothoid
     //!
     void reserve( int_type n );
 
@@ -1104,7 +1104,7 @@ namespace G2lib {
     real_type closure_gap_ty() const { return this->ty_End() - this->ty_Begin(); }
 
     //!
-    //! check if clothois list is closed
+    //! check if clothoid list is closed
     //!
     //! \param[in] tol_xy position tolerance
     //! \param[in] tol_tg angle (tangent) tolerance
@@ -1272,12 +1272,12 @@ namespace G2lib {
     ClothoidCurve const & getAtS( real_type s ) const;
 
     //!
-    //! Return the numbber of clothois of the list
+    //! Return the numbber of clothoid of the list
     //!
     int_type numSegment() const { return int_type(m_clotoidList.size()); }
 
     //!
-    //! The list of clothois has total length \f$ L \f$
+    //! The list of clothoid has total length \f$ L \f$
     //! the parameter \f$ s \f$ us recomputed as \f$ s+kL\f$ in such a way
     //! \f$ s+kL\in[0,L)\f$ with \f$ k\in\mathbb{Z} \f$.
     //!
@@ -1855,7 +1855,7 @@ namespace G2lib {
     operator << ( ostream_type & stream, ClothoidList const & CL );
 
     //!
-    //! Return the clothois list as a list of nodes and curvatures
+    //! Return the clothoid list as a list of nodes and curvatures
     //!
     //! \param[out] s     nodes
     //! \param[out] kappa curvature
@@ -1865,7 +1865,7 @@ namespace G2lib {
     getSK( real_type * s, real_type * kappa ) const;
 
     //!
-    //! Return the clothois list as a list of nodes and curvatures
+    //! Return the clothoid list as a list of nodes and curvatures
     //!
     //! \param[out] s     nodes
     //! \param[out] kappa curvature
@@ -1882,7 +1882,7 @@ namespace G2lib {
     }
 
     //!
-    //! Return the clothois list as a list of nodes angles and curvatures
+    //! Return the clothoid list as a list of nodes angles and curvatures
     //!
     //! \param[out] s     nodes
     //! \param[out] theta angles
@@ -1897,7 +1897,7 @@ namespace G2lib {
     ) const;
 
     //!
-    //! Return the clothois list as a list of nodes angles and curvatures
+    //! Return the clothoid list as a list of nodes angles and curvatures
     //!
     //! \param[out] s     nodes
     //! \param[out] theta angles


### PR DESCRIPTION
Followup PR to #23. It appears that some changes in that PR were overwritten yesterday due to changes not accounted for in develop. This PR re-applies the spelling fixes.

This PR is directed to master, we might want to merge master into develop after merging and rebuild the docs.