### PR TITLE
Adds missing includes to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ ENDFOREACH (F ${S})
 #  LIST( APPEND HEADERS ${RF} )
 #ENDFOREACH (F ${S})
 
-INCLUDE_DIRECTORIES( src lib3rd/include lib3rd/include/Utils )
+INCLUDE_DIRECTORIES( src submodules/Utils/src/ submodules/quarticRootsFlocke/src/ lib3rd/include lib3rd/include/Utils )
 
 SET( CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/lib )
 


### PR DESCRIPTION
This resolves the include problems mentioned in #26 and #28 when using cmake and make. This isn't an ideal solution, but it produces the following result on Ubuntu 16.04.
```
.
├── include
│   ├── Clothoids
│   │   ├── AABBtree.hxx
│   │   ├── BaseCurve.hxx
│   │   ├── BaseCurve_using.hxx
│   │   ├── Biarc.hxx
│   │   ├── BiarcList.hxx
│   │   ├── Circle.hxx
│   │   ├── ClothoidAsyPlot.hxx
│   │   ├── Clothoid.hxx
│   │   ├── ClothoidList.hxx
│   │   ├── Fresnel.hxx
│   │   ├── G2lib.hxx
│   │   ├── Line.hxx
│   │   ├── PolyLine.hxx
│   │   └── Triangle2D.hxx
│   └── Clothoids.hh
└── lib
    └── libClothoids_linux_static.a
```

I believe this to be the desired behavior. Can you confirm?

I've done the following and all those worked for me.

```
mkdir build
cd build
cmake ..
make
make install
```
 