### PR TITLE
fix: gcc compilation error (-fpermissive)

### DIFF
--- a/src/Clothoids/G2lib.hxx
+++ b/src/Clothoids/G2lib.hxx
@@ -141,7 +141,7 @@ namespace G2lib
   }
 
 
-  using G2derivative = struct
+  struct G2derivative
   {
     real_type L;
     real_type k0;


### PR DESCRIPTION
On Linux it failed compiling using gcc. Defining the named struct instead of using the unnamed one fixes the issue.

This was the error:
```
In file included from src/Clothoids.hh:184,
                 from src/Clothoid.cc:20:
src/Clothoids/Fresnel.hxx: At global scope:
src/Clothoids/Fresnel.hxx:340:9: error: ‘int G2lib::ClothoidData::build_G1(G2lib::real_type, G2lib::real_type, G2lib::real_type, G2lib::real_type, G2lib::real_type, G2lib::real_type, G2lib::G2derivative&, G2lib::real_type)’, declared using unnamed type, is used but never defined [-fpermissive]
  340 |     int build_G1(
      |         ^~~~~~~~
In file included from src/Clothoids.hh:180,
                 from src/Clothoid.cc:20:
src/Clothoids/G2lib.hxx:144:9: note: ‘using G2derivative = struct G2lib::<unnamed>’ does not refer to the unqualified type, so it is not used for linkage
  144 |   using G2derivative = struct
      |         ^~~~~~~~~~~~
```